### PR TITLE
ci: publish pre-compiled binaries on GitHub release

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -8,8 +8,8 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  upload:
+    name: Upload ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -19,39 +19,17 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            cross: true
           - target: x86_64-apple-darwin
             os: macos-13
           - target: aarch64-apple-darwin
             os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          targets: ${{ matrix.target }}
-
-      - name: Install cross
-        if: matrix.cross
-        run: cargo install cross
-
-      - name: Install dependencies
-        if: runner.os == 'Linux' && !matrix.cross
-        run: sudo apt-get update && sudo apt-get install -y libssl-dev pkg-config
-
-      - name: Build
-        run: |
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --release --target ${{ matrix.target }}
-          else
-            cargo build --release --target ${{ matrix.target }}
-          fi
-
-      - name: Package
-        run: tar czf colporteur-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release colporteur
-
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: colporteur-${{ matrix.target }}.tar.gz
+          bin: colporteur
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a new `build-binaries.yml` workflow triggered when release-plz publishes a GitHub release
- Uses [`taiki-e/upload-rust-binary-action`](https://github.com/taiki-e/upload-rust-binary-action) for cross-compilation, packaging, and upload
- Builds for 5 targets including Windows

Users without `cargo` can now download a pre-compiled binary from the GitHub release page.

## Targets
| Target | Runner |
|--------|--------|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` | `ubuntu-latest` |
| `x86_64-apple-darwin` | `macos-13` |
| `aarch64-apple-darwin` | `macos-latest` |
| `x86_64-pc-windows-msvc` | `windows-latest` |

## Test plan
- [ ] Merge to master and trigger a release via release-plz
- [ ] Verify all 5 binaries appear as assets on the GitHub release
- [ ] Download and run on at least one platform to confirm the binary works