### PR TITLE
ci: add multi-platform binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -22,6 +24,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
+        id: release
         uses: release-plz/action@v0.5
         with:
           command: release
@@ -55,3 +58,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload-binaries:
+    name: Upload ${{ matrix.target }}
+    needs: release-plz-release
+    if: needs.release-plz-release.outputs.releases_created == 'true'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-13
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: colporteur
+          target: ${{ matrix.target }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(cli)* add scan command to discover sender addresses ([#2](https://github.com/sripwoud/colporteur/pull/2))
+- _(cli)_ add scan command to discover sender addresses ([#2](https://github.com/sripwoud/colporteur/pull/2))
 
 ### Other
 


### PR DESCRIPTION
## Summary
- Adds `upload-binaries` job to `release.yml`, chained after `release-plz-release` via `needs` + `releases_created` output gate
- Uses [`taiki-e/upload-rust-binary-action`](https://github.com/taiki-e/upload-rust-binary-action) for cross-compilation and upload
- Builds for 5 targets: Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), Windows (x64)

## Why in the same workflow?
`GITHUB_TOKEN` events don't trigger other workflows (GitHub's anti-recursion safeguard). A separate `build-binaries.yml` triggered on `release: [published]` would never fire when release-plz creates the release.

Supersedes #3.

## Test plan
- [ ] Merge and wait for next release-plz release
- [ ] Verify binaries appear as assets on the GitHub release