### PR TITLE
docs: add pre-compiled binary install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Colporteur connects to IMAP mailboxes, fetches emails from configured senders, s
 
 ## Quick Start
 
-Install colporteur:
+Install colporteur from a [pre-compiled binary](https://github.com/sripwoud/colporteur/releases/latest) or via cargo:
 
 ```bash
 cargo install colporteur
@@ -55,7 +55,6 @@ Full documentation available at [colporteur.sripwoud.xyz](https://colporteur.sri
 
 ## Requirements
 
-- Rust/Cargo for installation
 - An IMAP-accessible email account with newsletters
 
 ## Develop

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,5 +1,11 @@
 # Installation
 
+## Pre-compiled binaries
+
+Download a binary for your platform from the [latest release](https://github.com/sripwoud/colporteur/releases/latest). Binaries are available for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x64).
+
+Extract it somewhere on your `PATH`, e.g. `~/.local/bin`.
+
 ## From crates.io
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds pre-compiled binary download instructions as the primary install method in README and docs
- Removes Rust/Cargo as a hard requirement
- Links to GitHub releases page for binary downloads