### PR TITLE
fix(imap): clamp UID search range start to 1

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -53,7 +53,8 @@ impl ImapClient {
     }
 
     pub fn search_from_since_uid(&mut self, sender: &str, last_uid: u32) -> eyre::Result<Vec<u32>> {
-        let query = format!("FROM \"{sender}\" UID {last_uid}:*");
+        let start = last_uid.max(1);
+        let query = format!("FROM \"{sender}\" UID {start}:*");
         let uids = match self.session.uid_search(&query) {
             Ok(uids) => uids,
             Err(imap::error::Error::No(no)) => {


### PR DESCRIPTION
## Summary
- `AppState::last_uid()` defaults to `0` on first run, producing the invalid IMAP query `UID 0:*` (RFC 3501 UIDs start at 1)
- Some servers respond with `NO`, causing the sender to never be processed
- Clamps the range start with `last_uid.max(1)` so first-run queries use `UID 1:*`

## Test plan
- [x] All 39 existing tests pass (first-run behavior already exercised by `full_pipeline_with_mock`)
- [x] Pre-commit hooks (clippy, dprint) pass

Closes #23