### PR TITLE
feat: support command-based password resolution

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ output_dir = "/var/lib/colporteur/feeds"
 [accounts.mail]
 server = "imap.example.com"
 username = "newsletters@example.com"
-password = "your-password"
+password = "your-password" # or "!pass show email/imap" for a password manager
 
 [feeds.weekly-digest]
 title = "Weekly Digest"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,12 +42,12 @@ max_entries = 10
 
 Defined under `[accounts.<name>]`.
 
-| Key        | Type   | Default    | Description            |
-| ---------- | ------ | ---------- | ---------------------- |
-| `server`   | string | _required_ | IMAP server hostname   |
-| `username` | string | _required_ | IMAP username          |
-| `password` | string | _required_ | IMAP password          |
-| `mailbox`  | string | `"INBOX"`  | IMAP mailbox to search |
+| Key        | Type   | Default    | Description                                               |
+| ---------- | ------ | ---------- | --------------------------------------------------------- |
+| `server`   | string | _required_ | IMAP server hostname                                      |
+| `username` | string | _required_ | IMAP username                                             |
+| `password` | string | _required_ | IMAP password or `!command` (see [Passwords](#passwords)) |
+| `mailbox`  | string | `"INBOX"`  | IMAP mailbox to search                                    |
 
 ## Feed settings
 
@@ -62,7 +62,31 @@ Defined under `[feeds.<name>]`. The `<name>` becomes the output filename (`<name
 
 ## Passwords
 
-Passwords are stored directly in the config file. Since the file contains secrets, ensure it is only readable by the owner:
+Passwords can be specified in three ways:
+
+| Syntax                               | Meaning                                             |
+| ------------------------------------ | --------------------------------------------------- |
+| `password = "secret"`                | Plain text                                          |
+| `password = "!pass show email/imap"` | Command — executes via `sh -c`, uses trimmed stdout |
+| `password = "!!starts-with-bang"`    | Escaped — literal password starting with `!`        |
+
+Command examples:
+
+```toml
+password = "!pass show email/imap"
+password = "!gopass show -o email/imap"
+password = "!op read 'op://Vault/IMAP/password'"
+password = "!secret-tool lookup service imap user newsletters"
+```
+
+Command execution details:
+
+- Runs via `sh -c <command>` with stdin closed
+- Trimmed stdout is used as the password
+- Fails with a clear error if the command exits non-zero or produces empty output
+- stderr is logged at debug level only
+
+Since the config file may contain secrets, ensure it is only readable by the owner:
 
 ```bash
 chmod 600 ~/.config/colporteur/config.toml

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,7 @@ Command execution details:
 - Trimmed stdout is used as the password
 - Fails with a clear error if the command exits non-zero or produces empty output
 - stderr is logged at debug level only
+- Unix-only — on Windows, command-based passwords are not supported; use a plain text value instead
 
 Since the config file may contain secrets, ensure it is only readable by the owner:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,7 +8,7 @@ output_dir = "/var/lib/colporteur/feeds"
 [accounts.mail]
 server = "mail.mxroute.com"
 username = "newsletters@domain.com"
-password = "secret"
+password = "secret" # or "!pass show email/newsletters" for a password manager
 
 [feeds.tech]
 title = "Tech Newsletters"
@@ -30,12 +30,12 @@ output_dir = "/var/lib/colporteur/feeds"
 [accounts.mxroute]
 server = "mail.mxroute.com"
 username = "news@domain.com"
-password = "secret"
+password = "secret" # or "!pass show email/mxroute" for a password manager
 
 [accounts.gmail]
 server = "imap.gmail.com"
 username = "user@gmail.com"
-password = "secret"
+password = "secret" # or "!op read 'op://Vault/Gmail/password'"
 
 [feeds.ideabrowser]
 title = "Ideabrowser Daily"

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -10,7 +10,7 @@ output_dir = "/var/lib/colporteur/feeds"
 [accounts.mxroute]
 server = "mail.mxroute.com"
 username = "news@domain.com"
-password = "your-imap-password"
+password = "your-imap-password" # or "!pass show email/imap" for a password manager
 
 [feeds.ideabrowser]
 title = "Ideabrowser Daily"

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -25,7 +25,7 @@ Config (TOML)
 Group feeds by account
   │
   ▼  (per account)
-Resolve password from env ──► Connect IMAP (TLS)
+Resolve password (plain/command) ──► Connect IMAP (TLS)
   │
   ▼
 Check UIDVALIDITY ──► Reset state if changed

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use eyre::{Context, bail};
 use serde::Deserialize;
@@ -18,6 +19,7 @@ output_dir = "/var/lib/colporteur/feeds"
 server = "imap.example.com"
 username = "newsletters@example.com"
 password = "your-imap-password"
+# password = "!pass show email/imap"  # or use a command (! prefix)
 # mailbox = "INBOX"  # default
 
 # Feeds (one per newsletter or group of senders)
@@ -74,8 +76,51 @@ pub struct Config {
 }
 
 impl AccountConfig {
-    pub fn resolve_password(&self) -> String {
-        self.password.clone()
+    pub fn resolve_password(&self) -> eyre::Result<String> {
+        if let Some(rest) = self.password.strip_prefix("!!") {
+            return Ok(format!("!{rest}"));
+        }
+
+        if let Some(cmd) = self.password.strip_prefix('!') {
+            return Self::run_password_command(cmd);
+        }
+
+        Ok(self.password.clone())
+    }
+
+    fn run_password_command(cmd: &str) -> eyre::Result<String> {
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .wrap_err_with(|| format!("failed to execute password command: {cmd}"))?;
+
+        if !output.status.success() {
+            let code = output
+                .status
+                .code()
+                .map_or("signal".to_string(), |c| c.to_string());
+            bail!("password command failed (exit {code}): {cmd}");
+        }
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            log::debug!("password command stderr: {stderr}");
+        }
+
+        let password = String::from_utf8(output.stdout)
+            .wrap_err_with(|| format!("password command output is not valid UTF-8: {cmd}"))?
+            .trim()
+            .to_string();
+
+        if password.is_empty() {
+            bail!("password command produced no output: {cmd}");
+        }
+
+        Ok(password)
     }
 }
 
@@ -281,15 +326,78 @@ senders = ["x@example.com"]
         );
     }
 
-    #[test]
-    fn resolve_password_returns_password() {
-        let account = AccountConfig {
+    fn account_with_password(password: &str) -> AccountConfig {
+        AccountConfig {
             server: "mail.example.com".to_string(),
             username: "user@example.com".to_string(),
-            password: "s3cr3t".to_string(),
+            password: password.to_string(),
             mailbox: "INBOX".to_string(),
-        };
-        assert_eq!(account.resolve_password(), "s3cr3t");
+        }
+    }
+
+    #[test]
+    fn resolve_plaintext_password() {
+        assert_eq!(
+            account_with_password("s3cr3t").resolve_password().unwrap(),
+            "s3cr3t"
+        );
+    }
+
+    #[test]
+    fn resolve_command_password() {
+        assert_eq!(
+            account_with_password("!echo secret123")
+                .resolve_password()
+                .unwrap(),
+            "secret123"
+        );
+    }
+
+    #[test]
+    fn resolve_command_trims_whitespace() {
+        assert_eq!(
+            account_with_password("!echo '  secret  '")
+                .resolve_password()
+                .unwrap(),
+            "secret"
+        );
+    }
+
+    #[test]
+    fn resolve_escape_literal_bang() {
+        assert_eq!(
+            account_with_password("!!not-a-command")
+                .resolve_password()
+                .unwrap(),
+            "!not-a-command"
+        );
+    }
+
+    #[test]
+    fn resolve_command_failure() {
+        let err = account_with_password("!false")
+            .resolve_password()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("exit"), "expected exit info in: {err}");
+    }
+
+    #[test]
+    fn resolve_command_empty_output() {
+        let err = account_with_password("!echo -n ''")
+            .resolve_password()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no output"), "expected 'no output' in: {err}");
+    }
+
+    #[test]
+    fn resolve_command_not_found() {
+        let err = account_with_password("!nonexistent_binary_xyz_99")
+            .resolve_password()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("nonexistent_binary_xyz_99"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,10 +106,13 @@ impl AccountConfig {
             .wrap_err_with(|| format!("failed to execute password command: {cmd}"))?;
 
         if !output.stderr.is_empty() {
-            log::debug!(
-                "password command produced output on stderr ({} bytes)",
-                output.stderr.len()
-            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let sanitized: String = stderr
+                .chars()
+                .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+                .take(200)
+                .collect();
+            log::debug!("password command stderr: {sanitized}");
         }
 
         if !output.status.success() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,19 +105,19 @@ impl AccountConfig {
             .output()
             .wrap_err_with(|| format!("failed to execute password command: {cmd}"))?;
 
+        if !output.stderr.is_empty() {
+            log::debug!(
+                "password command produced output on stderr ({} bytes)",
+                output.stderr.len()
+            );
+        }
+
         if !output.status.success() {
             let code = output
                 .status
                 .code()
                 .map_or("signal".to_string(), |c| c.to_string());
             bail!("password command failed (exit {code}): {cmd}");
-        }
-
-        if !output.stderr.is_empty() {
-            log::debug!(
-                "password command produced output on stderr ({} bytes)",
-                output.stderr.len()
-            );
         }
 
         let password = String::from_utf8(output.stdout)
@@ -397,7 +397,7 @@ senders = ["x@example.com"]
     #[test]
     #[cfg(unix)]
     fn resolve_command_empty_output() {
-        let err = account_with_password("!echo -n ''")
+        let err = account_with_password("!printf ''")
             .resolve_password()
             .unwrap_err()
             .to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
 use std::process::{Command, Stdio};
 
 use eyre::{Context, bail};
@@ -112,9 +113,11 @@ impl AccountConfig {
             bail!("password command failed (exit {code}): {cmd}");
         }
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if !stderr.is_empty() {
-            log::debug!("password command stderr: {stderr}");
+        if !output.stderr.is_empty() {
+            log::debug!(
+                "password command produced output on stderr ({} bytes)",
+                output.stderr.len()
+            );
         }
 
         let password = String::from_utf8(output.stdout)

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,12 @@ impl AccountConfig {
         Ok(self.password.clone())
     }
 
+    #[cfg(not(unix))]
+    fn run_password_command(cmd: &str) -> eyre::Result<String> {
+        bail!("command-based passwords are only supported on Unix: {cmd}");
+    }
+
+    #[cfg(unix)]
     fn run_password_command(cmd: &str) -> eyre::Result<String> {
         let output = Command::new("sh")
             .arg("-c")
@@ -344,6 +350,7 @@ senders = ["x@example.com"]
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_command_password() {
         assert_eq!(
             account_with_password("!echo secret123")
@@ -354,6 +361,7 @@ senders = ["x@example.com"]
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_command_trims_whitespace() {
         assert_eq!(
             account_with_password("!echo '  secret  '")
@@ -374,6 +382,7 @@ senders = ["x@example.com"]
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_command_failure() {
         let err = account_with_password("!false")
             .resolve_password()
@@ -383,6 +392,7 @@ senders = ["x@example.com"]
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_command_empty_output() {
         let err = account_with_password("!echo -n ''")
             .resolve_password()
@@ -392,6 +402,7 @@ senders = ["x@example.com"]
     }
 
     #[test]
+    #[cfg(unix)]
     fn resolve_command_not_found() {
         let err = account_with_password("!nonexistent_binary_xyz_99")
             .resolve_password()

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -82,7 +82,9 @@ pub fn run(
                         new_entries: 0,
                         output: None,
                         ok: false,
-                        error: Some("failed to resolve password".to_string()),
+                        error: Some(
+                            "failed to resolve password; re-run with -vv for details".to_string(),
+                        ),
                     });
                 }
                 continue;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -74,14 +74,15 @@ pub fn run(
         let password = match account.resolve_password() {
             Ok(p) => p,
             Err(e) => {
-                log::error!("account '{account_name}': {e}");
+                log::error!("account '{account_name}': failed to resolve password");
+                log::debug!("account '{account_name}': {e}");
                 for (feed_key, _) in feeds {
                     all_results.push(FeedResult {
                         key: (*feed_key).to_string(),
                         new_entries: 0,
                         output: None,
                         ok: false,
-                        error: Some(format!("{e}")),
+                        error: Some("failed to resolve password".to_string()),
                     });
                 }
                 continue;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -775,10 +775,11 @@ pub fn test_connections(
         .map(|(name, account)| {
             let result = account
                 .resolve_password()
+                .wrap_err_with(|| format!("password resolution failed for '{name}'"))
                 .and_then(|password| {
                     ImapClient::test_connection(&account.server, &account.username, &password)
-                })
-                .wrap_err_with(|| format!("connection test failed for '{name}'"));
+                        .wrap_err_with(|| format!("connection test failed for '{name}'"))
+                });
             (name.clone(), result)
         })
         .collect()

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -71,7 +71,22 @@ pub fn run(
             }
         };
 
-        let password = account.resolve_password();
+        let password = match account.resolve_password() {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!("account '{account_name}': {e}");
+                for (feed_key, _) in feeds {
+                    all_results.push(FeedResult {
+                        key: (*feed_key).to_string(),
+                        new_entries: 0,
+                        output: None,
+                        ok: false,
+                        error: Some(format!("{e}")),
+                    });
+                }
+                continue;
+            }
+        };
 
         let mut source = match ImapClient::connect(&account.server, &account.username, &password) {
             Ok(c) => c,
@@ -758,8 +773,11 @@ pub fn test_connections(
         .iter()
         .filter(|(name, _)| account_filter.is_none_or(|f| f == name.as_str()))
         .map(|(name, account)| {
-            let password = account.resolve_password();
-            let result = ImapClient::test_connection(&account.server, &account.username, &password)
+            let result = account
+                .resolve_password()
+                .and_then(|password| {
+                    ImapClient::test_connection(&account.server, &account.username, &password)
+                })
                 .wrap_err_with(|| format!("connection test failed for '{name}'"));
             (name.clone(), result)
         })

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -21,11 +21,12 @@ pub fn run(config: &Config, account_filter: Option<&str>) -> Vec<ScanReport> {
         let password = match account.resolve_password() {
             Ok(p) => p,
             Err(e) => {
-                log::error!("account '{account_name}': {e}");
+                log::error!("account '{account_name}': failed to resolve password");
+                log::debug!("account '{account_name}': {e}");
                 reports.push(ScanReport {
                     account: account_name.clone(),
                     senders: Vec::new(),
-                    error: Some(format!("{e}")),
+                    error: Some("failed to resolve password".to_string()),
                 });
                 continue;
             }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -26,7 +26,9 @@ pub fn run(config: &Config, account_filter: Option<&str>) -> Vec<ScanReport> {
                 reports.push(ScanReport {
                     account: account_name.clone(),
                     senders: Vec::new(),
-                    error: Some("failed to resolve password".to_string()),
+                    error: Some(
+                        "failed to resolve password; re-run with -vv for details".to_string(),
+                    ),
                 });
                 continue;
             }

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -18,7 +18,18 @@ pub fn run(config: &Config, account_filter: Option<&str>) -> Vec<ScanReport> {
             continue;
         }
 
-        let password = account.resolve_password();
+        let password = match account.resolve_password() {
+            Ok(p) => p,
+            Err(e) => {
+                log::error!("account '{account_name}': {e}");
+                reports.push(ScanReport {
+                    account: account_name.clone(),
+                    senders: Vec::new(),
+                    error: Some(format!("{e}")),
+                });
+                continue;
+            }
+        };
 
         let mut client = match ImapClient::connect(&account.server, &account.username, &password) {
             Ok(c) => c,


### PR DESCRIPTION
## Summary
- Passwords prefixed with `!` are executed as shell commands via `sh -c`, with trimmed stdout used as the password
- `!!` escapes a literal `!` prefix (chosen over `\!` which is invalid TOML)
- Plain string passwords continue to work unchanged
- No new dependencies — uses `std::process::Command`

## Test plan
- [x] 45 tests pass (6 new + 39 existing)
- [x] `resolve_plaintext_password` — plain strings unchanged
- [x] `resolve_command_password` — `!echo secret123` returns `secret123`
- [x] `resolve_command_trims_whitespace` — trailing/leading whitespace stripped
- [x] `resolve_escape_literal_bang` — `!!x` returns `!x`
- [x] `resolve_command_failure` — non-zero exit produces clear error
- [x] `resolve_command_empty_output` — empty stdout produces clear error
- [x] `resolve_command_not_found` — missing binary surfaces in error
- [x] Pre-commit hooks (clippy, dprint) pass

Closes #20