### PR TITLE
feat: add `export-opml` command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -87,6 +87,27 @@ ideabrowser          mxroute      notifications@mail.ideabrowser.com   142
 mixed                gmail        noreply@health.com, tips@parent...   87
 ```
 
+### `export-opml`
+
+Export configured feeds as an OPML 2.0 file for importing into RSS readers.
+
+```bash
+colporteur export-opml --base-url URL [-o FILE]
+```
+
+| Flag               | Short | Description                                       |
+| ------------------ | ----- | ------------------------------------------------- |
+| `--base-url <URL>` |       | Base URL for feed links (required; no `?` or `#`) |
+| `--output <FILE>`  | `-o`  | Output file path (default: stdout)                |
+
+**Example:**
+
+```bash
+colporteur export-opml --base-url https://feeds.example.com
+colporteur export-opml --base-url https://feeds.example.com -o feeds.opml
+colporteur export-opml --base-url https://feeds.example.com -o feeds.opml -q
+```
+
 ## Logging
 
 Verbosity is controlled by `-v` flags or the `RUST_LOG` environment variable:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,21 @@ pub enum Command {
     Init,
     #[command(about = "Scan IMAP account(s) and list unique sender addresses")]
     Scan(ScanArgs),
+    #[command(about = "Export configured feeds as an OPML file")]
+    ExportOpml(ExportOpmlArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ExportOpmlArgs {
+    #[arg(long, value_name = "URL", help = "Base URL for feed links")]
+    pub base_url: String,
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        help = "Output file (default: stdout)"
+    )]
+    pub output: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod email;
 pub mod feed;
 pub mod fetch;
 pub mod imap;
+pub mod opml;
 pub mod sanitize;
 pub mod scan;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,13 @@ fn cmd_list(config: &Config, json: bool) -> i32 {
 }
 
 fn cmd_export_opml(config: &Config, args: &ExportOpmlArgs, quiet: bool) -> i32 {
-    let content = opml::generate(config, &args.base_url);
+    let content = match opml::generate(config, &args.base_url) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
 
     match &args.output {
         Some(path) => match std::fs::write(path, &content) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
-use colporteur::cli::{Cli, Command, FetchArgs, ScanArgs, TestArgs};
+use colporteur::cli::{Cli, Command, ExportOpmlArgs, FetchArgs, ScanArgs, TestArgs};
 use colporteur::config::Config;
 use colporteur::fetch;
+use colporteur::opml;
 use colporteur::scan;
 use colporteur::state::AppState;
 
@@ -26,6 +27,7 @@ fn main() {
         Command::Test(args) => cmd_test(&config, &args, cli.json),
         Command::List => cmd_list(&config, cli.json),
         Command::Scan(args) => cmd_scan(&config, &args, cli.json, cli.quiet),
+        Command::ExportOpml(args) => cmd_export_opml(&config, &args),
         Command::Init => unreachable!(),
     };
 
@@ -292,4 +294,25 @@ fn cmd_list(config: &Config, json: bool) -> i32 {
     }
 
     0
+}
+
+fn cmd_export_opml(config: &Config, args: &ExportOpmlArgs) -> i32 {
+    let content = opml::generate(config, &args.base_url);
+
+    match &args.output {
+        Some(path) => match std::fs::write(path, &content) {
+            Ok(()) => {
+                eprintln!("wrote {path}");
+                0
+            }
+            Err(e) => {
+                eprintln!("error: failed to write {path}: {e}");
+                1
+            }
+        },
+        None => {
+            print!("{content}");
+            0
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
         Command::Test(args) => cmd_test(&config, &args, cli.json),
         Command::List => cmd_list(&config, cli.json),
         Command::Scan(args) => cmd_scan(&config, &args, cli.json, cli.quiet),
-        Command::ExportOpml(args) => cmd_export_opml(&config, &args),
+        Command::ExportOpml(args) => cmd_export_opml(&config, &args, cli.quiet),
         Command::Init => unreachable!(),
     };
 
@@ -296,13 +296,15 @@ fn cmd_list(config: &Config, json: bool) -> i32 {
     0
 }
 
-fn cmd_export_opml(config: &Config, args: &ExportOpmlArgs) -> i32 {
+fn cmd_export_opml(config: &Config, args: &ExportOpmlArgs, quiet: bool) -> i32 {
     let content = opml::generate(config, &args.base_url);
 
     match &args.output {
         Some(path) => match std::fs::write(path, &content) {
             Ok(()) => {
-                eprintln!("wrote {path}");
+                if !quiet {
+                    eprintln!("wrote {path}");
+                }
                 0
             }
             Err(e) => {

--- a/src/opml.rs
+++ b/src/opml.rs
@@ -8,7 +8,10 @@ fn escape_xml(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-pub fn generate(config: &Config, base_url: &str) -> String {
+pub fn generate(config: &Config, base_url: &str) -> eyre::Result<String> {
+    if base_url.contains('?') || base_url.contains('#') {
+        eyre::bail!("base URL must not contain query string or fragment: {base_url}");
+    }
     let base = base_url.trim_end_matches('/');
 
     let mut keys: Vec<&String> = config.feeds.keys().collect();
@@ -26,7 +29,7 @@ pub fn generate(config: &Config, base_url: &str) -> String {
         })
         .collect();
 
-    format!(
+    Ok(format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <opml version=\"2.0\">\n\
          \x20 <head>\n\
@@ -37,7 +40,7 @@ pub fn generate(config: &Config, base_url: &str) -> String {
          \x20 </body>\n\
          </opml>\n",
         outlines.join("\n")
-    )
+    ))
 }
 
 #[cfg(test)]
@@ -80,7 +83,7 @@ mod tests {
     #[test]
     fn generates_valid_opml_with_single_feed() {
         let config = test_config(vec![("newsletter", "My Newsletter")]);
-        let opml = generate(&config, "http://localhost:8085");
+        let opml = generate(&config, "http://localhost:8085").unwrap();
 
         assert!(opml.starts_with("<?xml version=\"1.0\""));
         assert!(opml.contains("<opml version=\"2.0\">"));
@@ -93,7 +96,7 @@ mod tests {
     #[test]
     fn generates_feeds_in_sorted_order() {
         let config = test_config(vec![("zebra", "Zebra Feed"), ("alpha", "Alpha Feed")]);
-        let opml = generate(&config, "https://feeds.example.com");
+        let opml = generate(&config, "https://feeds.example.com").unwrap();
 
         let alpha_pos = opml.find("alpha.xml").unwrap();
         let zebra_pos = opml.find("zebra.xml").unwrap();
@@ -103,7 +106,7 @@ mod tests {
     #[test]
     fn escapes_xml_special_characters_in_title() {
         let config = test_config(vec![("test", "Tom & Jerry's <News>")]);
-        let opml = generate(&config, "http://localhost:8085");
+        let opml = generate(&config, "http://localhost:8085").unwrap();
 
         assert!(opml.contains("Tom &amp; Jerry&apos;s &lt;News&gt;"));
     }
@@ -111,24 +114,30 @@ mod tests {
     #[test]
     fn strips_trailing_slash_from_base_url() {
         let config = test_config(vec![("feed", "Feed")]);
-        let opml = generate(&config, "http://localhost:8085/");
+        let opml = generate(&config, "http://localhost:8085/").unwrap();
 
         assert!(opml.contains("http://localhost:8085/feed.xml"));
         assert!(!opml.contains("http://localhost:8085//feed.xml"));
     }
 
     #[test]
-    fn escapes_xml_special_characters_in_url() {
+    fn rejects_base_url_with_query_string() {
         let config = test_config(vec![("feed", "Feed")]);
-        let opml = generate(&config, "http://localhost:8085/path?a=1&b=2");
+        let result = generate(&config, "http://localhost:8085/path?a=1&b=2");
+        assert!(result.is_err());
+    }
 
-        assert!(opml.contains("xmlUrl=\"http://localhost:8085/path?a=1&amp;b=2/feed.xml\""));
+    #[test]
+    fn rejects_base_url_with_fragment() {
+        let config = test_config(vec![("feed", "Feed")]);
+        let result = generate(&config, "http://localhost:8085/path#section");
+        assert!(result.is_err());
     }
 
     #[test]
     fn handles_empty_feeds() {
         let config = test_config(vec![]);
-        let opml = generate(&config, "http://localhost:8085");
+        let opml = generate(&config, "http://localhost:8085").unwrap();
 
         assert!(opml.contains("<body>"));
         assert!(opml.contains("</body>"));

--- a/src/opml.rs
+++ b/src/opml.rs
@@ -1,0 +1,129 @@
+use crate::config::Config;
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+pub fn generate(config: &Config, base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+
+    let mut keys: Vec<&String> = config.feeds.keys().collect();
+    keys.sort();
+
+    let outlines: Vec<String> = keys
+        .iter()
+        .map(|key| {
+            let feed = &config.feeds[*key];
+            let title = escape_xml(&feed.title);
+            let url = format!("{base}/{key}.xml");
+            format!(
+                "    <outline text=\"{title}\" title=\"{title}\" xmlUrl=\"{url}\" type=\"rss\"/>"
+            )
+        })
+        .collect();
+
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <opml version=\"2.0\">\n\
+         \x20 <head>\n\
+         \x20   <title>Colporteur Feeds</title>\n\
+         \x20 </head>\n\
+         \x20 <body>\n\
+         {}\n\
+         \x20 </body>\n\
+         </opml>\n",
+        outlines.join("\n")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{AccountConfig, Config, FeedConfig};
+    use std::collections::HashMap;
+
+    fn test_config(feeds: Vec<(&str, &str)>) -> Config {
+        let mut feed_map = HashMap::new();
+        for (key, title) in feeds {
+            feed_map.insert(
+                key.to_string(),
+                FeedConfig {
+                    title: title.to_string(),
+                    account: "test".to_string(),
+                    senders: vec!["a@b.com".to_string()],
+                    max_entries: None,
+                },
+            );
+        }
+        let mut accounts = HashMap::new();
+        accounts.insert(
+            "test".to_string(),
+            AccountConfig {
+                server: "imap.test.com".to_string(),
+                username: "user@test.com".to_string(),
+                password: "pass".to_string(),
+                mailbox: "INBOX".to_string(),
+            },
+        );
+        Config {
+            output_dir: "/tmp/feeds".to_string(),
+            max_entries: 50,
+            accounts,
+            feeds: feed_map,
+        }
+    }
+
+    #[test]
+    fn generates_valid_opml_with_single_feed() {
+        let config = test_config(vec![("newsletter", "My Newsletter")]);
+        let opml = generate(&config, "http://localhost:8085");
+
+        assert!(opml.starts_with("<?xml version=\"1.0\""));
+        assert!(opml.contains("<opml version=\"2.0\">"));
+        assert!(opml.contains("text=\"My Newsletter\""));
+        assert!(opml.contains("xmlUrl=\"http://localhost:8085/newsletter.xml\""));
+        assert!(opml.contains("type=\"rss\""));
+        assert!(opml.contains("</opml>"));
+    }
+
+    #[test]
+    fn generates_feeds_in_sorted_order() {
+        let config = test_config(vec![("zebra", "Zebra Feed"), ("alpha", "Alpha Feed")]);
+        let opml = generate(&config, "https://feeds.example.com");
+
+        let alpha_pos = opml.find("alpha.xml").unwrap();
+        let zebra_pos = opml.find("zebra.xml").unwrap();
+        assert!(alpha_pos < zebra_pos);
+    }
+
+    #[test]
+    fn escapes_xml_special_characters_in_title() {
+        let config = test_config(vec![("test", "Tom & Jerry's <News>")]);
+        let opml = generate(&config, "http://localhost:8085");
+
+        assert!(opml.contains("Tom &amp; Jerry&apos;s &lt;News&gt;"));
+    }
+
+    #[test]
+    fn strips_trailing_slash_from_base_url() {
+        let config = test_config(vec![("feed", "Feed")]);
+        let opml = generate(&config, "http://localhost:8085/");
+
+        assert!(opml.contains("http://localhost:8085/feed.xml"));
+        assert!(!opml.contains("http://localhost:8085//feed.xml"));
+    }
+
+    #[test]
+    fn handles_empty_feeds() {
+        let config = test_config(vec![]);
+        let opml = generate(&config, "http://localhost:8085");
+
+        assert!(opml.contains("<body>"));
+        assert!(opml.contains("</body>"));
+        assert!(!opml.contains("<outline"));
+    }
+}

--- a/src/opml.rs
+++ b/src/opml.rs
@@ -19,7 +19,7 @@ pub fn generate(config: &Config, base_url: &str) -> String {
         .map(|key| {
             let feed = &config.feeds[*key];
             let title = escape_xml(&feed.title);
-            let url = format!("{base}/{key}.xml");
+            let url = escape_xml(&format!("{base}/{key}.xml"));
             format!(
                 "    <outline text=\"{title}\" title=\"{title}\" xmlUrl=\"{url}\" type=\"rss\"/>"
             )
@@ -115,6 +115,14 @@ mod tests {
 
         assert!(opml.contains("http://localhost:8085/feed.xml"));
         assert!(!opml.contains("http://localhost:8085//feed.xml"));
+    }
+
+    #[test]
+    fn escapes_xml_special_characters_in_url() {
+        let config = test_config(vec![("feed", "Feed")]);
+        let opml = generate(&config, "http://localhost:8085/path?a=1&b=2");
+
+        assert!(opml.contains("xmlUrl=\"http://localhost:8085/path?a=1&amp;b=2/feed.xml\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `colporteur export-opml --base-url <url>` command that generates OPML 2.0 from configured feeds
- Supports `--output` / `-o` to write to file (defaults to stdout)
- No IMAP connection needed — reads config only
- Feeds are sorted alphabetically for deterministic output

## Motivation

Enables automated feed subscription in RSS readers (e.g., FreshRSS OPML import) as part of deployment pipelines. See sripwoud/auberge#172.

## Test plan

- [x] 5 unit tests covering: single feed, sorted order, XML escaping, trailing slash handling, empty feeds
- [x] `cargo clippy` clean
- [x] All 41 tests pass

Closes #28