### PR TITLE
feat: strip email marketing noise from feed content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -65,6 +80,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -180,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -190,11 +214,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -202,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -214,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -240,6 +264,7 @@ dependencies = [
  "mailparse",
  "native-tls",
  "openssl",
+ "regex",
  "serde",
  "serde_json",
  "toml",
@@ -437,7 +462,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -541,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -786,9 +811,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e3d65f018c6ae946ab16e80944b97096ed73c35b221d1c478a6c81d8f57940"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -799,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17c2b211d863c7fde02cbea8a3c1a439b98e109286554f2860bdded7ff83818"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -810,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.90"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -832,17 +857,16 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
@@ -980,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -992,9 +1016,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1033,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -1235,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1250,9 +1274,9 @@ checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1339,9 +1363,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys",
 ]
@@ -1518,12 +1542,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1691,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1704,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1714,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1727,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.113"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -1850,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ imap = "3.0.0-alpha.15"
 log = "0.4"
 mailparse = "0.16"
 native-tls = "0.2"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 static PREHEADER_PADDING_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?:(?:&nbsp;|\x{00A0})[\x{200B}-\x{200D}\x{FEFF}]*){3,}").unwrap()
+    Regex::new(r"(?:(?:&nbsp;|\x{00A0})[\x{200B}-\x{200D}\x{FEFF}]*){10,}").unwrap()
 });
 
 static EXCESSIVE_BR_RE: LazyLock<Regex> =
@@ -187,8 +187,15 @@ mod tests {
     }
 
     #[test]
-    fn preserves_one_or_two_nbsp() {
+    fn preserves_short_nbsp_runs() {
         let html = "<p>hello&nbsp;&nbsp;world</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
+    fn preserves_nbsp_indentation_in_pre() {
+        let html = "<pre>&nbsp;&nbsp;&nbsp;indent</pre>";
         let result = clean_email_noise(html);
         assert_eq!(result, html);
     }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -3,8 +3,11 @@ use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
-static PREHEADER_PADDING_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?:(?:&nbsp;|\x{00A0})[\x{200B}-\x{200D}\x{FEFF}]*){10,}").unwrap()
+static NBSP_PADDING_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?:(?:&nbsp;|\x{00A0})[\x{200B}-\x{200D}\x{FEFF}]+){3,}|(?:(?:&nbsp;|\x{00A0})\s*){10,}",
+    )
+    .unwrap()
 });
 
 static EXCESSIVE_BR_RE: LazyLock<Regex> =
@@ -67,10 +70,17 @@ pub fn sanitize_html(html: &str) -> String {
 }
 
 fn clean_email_noise(html: &str) -> String {
-    let result = PREHEADER_PADDING_RE.replace_all(html, " ");
+    let result = NBSP_PADDING_RE.replace_all(html, " ");
     let result = EXCESSIVE_BR_RE.replace_all(&result, "<br><br>");
-    let result = EMPTY_BLOCK_RE.replace_all(&result, "");
-    let result = MULTI_NEWLINES_RE.replace_all(&result, ">\n\n<");
+    let mut current = result.into_owned();
+    loop {
+        let cleaned = EMPTY_BLOCK_RE.replace_all(&current, "");
+        if let std::borrow::Cow::Borrowed(_) = cleaned {
+            break;
+        }
+        current = cleaned.into_owned();
+    }
+    let result = MULTI_NEWLINES_RE.replace_all(&current, ">\n\n<");
     result.trim().to_string()
 }
 
@@ -226,6 +236,28 @@ mod tests {
         let html = "<p></p><p>content</p>";
         let result = clean_email_noise(html);
         assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn removes_nested_empty_blocks() {
+        let html = "<div><p></p></div><p>content</p>";
+        let result = clean_email_noise(html);
+        assert!(
+            !result.contains("<div>"),
+            "outer div should be removed after inner p"
+        );
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn strips_short_nbsp_with_zero_width_chars() {
+        let padding = format!("&nbsp;\u{200C}&nbsp;\u{200C}&nbsp;\u{200C}");
+        let html = format!("<div>{padding}</div><p>content</p>");
+        let result = clean_email_noise(&html);
+        assert!(
+            !result.contains("&nbsp;\u{200C}&nbsp;"),
+            "NBSP+ZW runs should be stripped even at 3 repetitions"
+        );
     }
 
     #[test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -17,7 +17,8 @@ static EMPTY_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"<div>\s*(?:&nbsp;|\x{00A0})?\s*</div>|<p>\s*(?:&nbsp;|\x{00A0})?\s*</p>").unwrap()
 });
 
-static MULTI_NEWLINES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r">\n{3,}<").unwrap());
+static MULTI_NEWLINES_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r">(?:\r?\n){3,}<").unwrap());
 
 pub fn sanitize_html(html: &str) -> String {
     let mut builder = Builder::new();
@@ -69,11 +70,14 @@ pub fn sanitize_html(html: &str) -> String {
     clean_email_noise(&without_pixels)
 }
 
+const MAX_EMPTY_BLOCK_PASSES: usize = 10;
+
 fn clean_email_noise(html: &str) -> String {
-    let result = NBSP_PADDING_RE.replace_all(html, " ");
+    let (work, preserved) = protect_preformatted(html);
+    let result = NBSP_PADDING_RE.replace_all(&work, " ");
     let result = EXCESSIVE_BR_RE.replace_all(&result, "<br><br>");
     let mut current = result.into_owned();
-    loop {
+    for _ in 0..MAX_EMPTY_BLOCK_PASSES {
         let cleaned = EMPTY_BLOCK_RE.replace_all(&current, "");
         if let std::borrow::Cow::Borrowed(_) = cleaned {
             break;
@@ -81,7 +85,40 @@ fn clean_email_noise(html: &str) -> String {
         current = cleaned.into_owned();
     }
     let result = MULTI_NEWLINES_RE.replace_all(&current, ">\n\n<");
-    result.trim().to_string()
+    let trimmed = result.trim().to_string();
+    restore_preformatted(&trimmed, &preserved)
+}
+
+fn protect_preformatted(html: &str) -> (String, Vec<String>) {
+    let mut result = html.to_string();
+    let mut blocks = Vec::new();
+    for tag in ["pre", "code"] {
+        let open = format!("<{tag}");
+        let close = format!("</{tag}>");
+        let mut pos = 0;
+        while let Some(start) = result[pos..].find(&open) {
+            let abs_start = pos + start;
+            if let Some(end_rel) = result[abs_start..].find(&close) {
+                let abs_end = abs_start + end_rel + close.len();
+                let placeholder = format!("COLPORTEUR_PRESERVED_{}", blocks.len());
+                blocks.push(result[abs_start..abs_end].to_string());
+                result.replace_range(abs_start..abs_end, &placeholder);
+                pos = abs_start + placeholder.len();
+            } else {
+                break;
+            }
+        }
+    }
+    (result, blocks)
+}
+
+fn restore_preformatted(html: &str, blocks: &[String]) -> String {
+    let mut result = html.to_string();
+    for (i, block) in blocks.iter().enumerate() {
+        let placeholder = format!("COLPORTEUR_PRESERVED_{i}");
+        result = result.replace(&placeholder, block);
+    }
+    result
 }
 
 fn remove_tracking_pixels(html: &str) -> String {
@@ -224,9 +261,28 @@ mod tests {
 
     #[test]
     fn preserves_nbsp_indentation_in_pre() {
-        let html = "<pre>&nbsp;&nbsp;&nbsp;indent</pre>";
+        let nbsp_12 = "&nbsp;".repeat(12);
+        let html = format!("<pre>{nbsp_12}indent</pre>");
+        let result = clean_email_noise(&html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
+    fn preserves_br_inside_pre() {
+        let html = "<pre>a<br><br><br><br>b</pre>";
         let result = clean_email_noise(html);
         assert_eq!(result, html);
+    }
+
+    #[test]
+    fn preserves_code_block_content() {
+        let nbsp_15 = "&nbsp;".repeat(15);
+        let html = format!("<code>{nbsp_15}indented</code><p>text</p>");
+        let result = clean_email_noise(&html);
+        assert!(
+            result.contains(&nbsp_15),
+            "code block content must be preserved"
+        );
     }
 
     #[test]
@@ -289,6 +345,13 @@ mod tests {
     #[test]
     fn collapses_multi_newlines_between_tags() {
         let html = "<p>one</p>\n\n\n\n\n<p>two</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>one</p>\n\n<p>two</p>");
+    }
+
+    #[test]
+    fn collapses_crlf_newlines_between_tags() {
+        let html = "<p>one</p>\r\n\r\n\r\n\r\n<p>two</p>";
         let result = clean_email_noise(html);
         assert_eq!(result, "<p>one</p>\n\n<p>two</p>");
     }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -14,7 +14,7 @@ static EMPTY_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"<div>\s*(?:&nbsp;|\x{00A0})?\s*</div>|<p>\s*(?:&nbsp;|\x{00A0})?\s*</p>").unwrap()
 });
 
-static MULTI_NEWLINES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+static MULTI_NEWLINES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r">\n{3,}<").unwrap());
 
 pub fn sanitize_html(html: &str) -> String {
     let mut builder = Builder::new();
@@ -62,15 +62,15 @@ pub fn sanitize_html(html: &str) -> String {
         .url_schemes(HashSet::from(["http", "https"]));
 
     let sanitized = builder.clean(html).to_string();
-    let cleaned = clean_email_noise(&sanitized);
-    remove_tracking_pixels(&cleaned)
+    let without_pixels = remove_tracking_pixels(&sanitized);
+    clean_email_noise(&without_pixels)
 }
 
 fn clean_email_noise(html: &str) -> String {
     let result = PREHEADER_PADDING_RE.replace_all(html, " ");
     let result = EXCESSIVE_BR_RE.replace_all(&result, "<br><br>");
     let result = EMPTY_BLOCK_RE.replace_all(&result, "");
-    let result = MULTI_NEWLINES_RE.replace_all(&result, "\n\n");
+    let result = MULTI_NEWLINES_RE.replace_all(&result, ">\n\n<");
     result.trim().to_string()
 }
 
@@ -229,10 +229,17 @@ mod tests {
     }
 
     #[test]
-    fn collapses_multi_newlines() {
+    fn collapses_multi_newlines_between_tags() {
         let html = "<p>one</p>\n\n\n\n\n<p>two</p>";
         let result = clean_email_noise(html);
         assert_eq!(result, "<p>one</p>\n\n<p>two</p>");
+    }
+
+    #[test]
+    fn preserves_newlines_inside_pre() {
+        let html = "<pre>line1\n\n\n\nline4</pre>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, html);
     }
 
     #[test]
@@ -240,6 +247,17 @@ mod tests {
         let html = "\n\n  <p>content</p>  \n\n";
         let result = clean_email_noise(html);
         assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn tracking_pixel_removal_then_empty_block_cleanup() {
+        let html = r#"<div><img width="1" height="1" src="https://track.example.com/pixel.gif"></div><p>content</p>"#;
+        let result = sanitize_html(html);
+        assert!(
+            !result.contains("<div></div>"),
+            "empty wrapper after pixel removal should be cleaned"
+        );
+        assert!(result.contains("content"));
     }
 
     #[test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -14,7 +14,8 @@ static EXCESSIVE_BR_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?:<br\s*/?>[\s]*){3,}").unwrap());
 
 static EMPTY_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"<div>\s*(?:&nbsp;|\x{00A0})?\s*</div>|<p>\s*(?:&nbsp;|\x{00A0})?\s*</p>").unwrap()
+    Regex::new(r"<div>\s*(?:(?:&nbsp;|\x{00A0})\s*)*</div>|<p>\s*(?:(?:&nbsp;|\x{00A0})\s*)*</p>")
+        .unwrap()
 });
 
 static MULTI_NEWLINES_RE: LazyLock<Regex> =
@@ -100,7 +101,7 @@ fn protect_preformatted(html: &str) -> (String, Vec<String>) {
             let abs_start = pos + start;
             if let Some(end_rel) = result[abs_start..].find(&close) {
                 let abs_end = abs_start + end_rel + close.len();
-                let placeholder = format!("COLPORTEUR_PRESERVED_{}", blocks.len());
+                let placeholder = format!("\x00COLPORTEUR_{}\x00", blocks.len());
                 blocks.push(result[abs_start..abs_end].to_string());
                 result.replace_range(abs_start..abs_end, &placeholder);
                 pos = abs_start + placeholder.len();
@@ -115,7 +116,7 @@ fn protect_preformatted(html: &str) -> (String, Vec<String>) {
 fn restore_preformatted(html: &str, blocks: &[String]) -> String {
     let mut result = html.to_string();
     for (i, block) in blocks.iter().enumerate() {
-        let placeholder = format!("COLPORTEUR_PRESERVED_{i}");
+        let placeholder = format!("\x00COLPORTEUR_{i}\x00");
         result = result.replace(&placeholder, block);
     }
     result
@@ -300,6 +301,13 @@ mod tests {
     }
 
     #[test]
+    fn removes_div_with_multiple_nbsp() {
+        let html = "<div>&nbsp;&nbsp;&nbsp;</div><p>content</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
     fn removes_empty_div() {
         let html = "<div>  </div><p>content</p>";
         let result = clean_email_noise(html);
@@ -379,6 +387,23 @@ mod tests {
             "empty wrapper after pixel removal should be cleaned"
         );
         assert!(result.contains("content"));
+    }
+
+    #[test]
+    fn restore_preformatted_no_collision_with_10_plus_blocks() {
+        let blocks: Vec<String> = (0..12).map(|i| format!("<code>block{i}</code>")).collect();
+        let mut html = String::new();
+        for i in 0..12 {
+            html.push_str(&format!("\x00COLPORTEUR_{i}\x00"));
+        }
+        let result = restore_preformatted(&html, &blocks);
+        for i in 0..12 {
+            assert!(
+                result.contains(&format!("<code>block{i}</code>")),
+                "block {i} should be restored correctly"
+            );
+        }
+        assert!(!result.contains("COLPORTEUR_"));
     }
 
     #[test]

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -78,12 +78,17 @@ fn clean_email_noise(html: &str) -> String {
     let result = NBSP_PADDING_RE.replace_all(&work, " ");
     let result = EXCESSIVE_BR_RE.replace_all(&result, "<br><br>");
     let mut current = result.into_owned();
+    let mut stabilized = false;
     for _ in 0..MAX_EMPTY_BLOCK_PASSES {
         let cleaned = EMPTY_BLOCK_RE.replace_all(&current, "");
         if let std::borrow::Cow::Borrowed(_) = cleaned {
+            stabilized = true;
             break;
         }
         current = cleaned.into_owned();
+    }
+    if !stabilized {
+        log::warn!("empty-block cleanup did not stabilize within {MAX_EMPTY_BLOCK_PASSES} passes");
     }
     let result = MULTI_NEWLINES_RE.replace_all(&current, ">\n\n<");
     let trimmed = result.trim().to_string();

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -1,5 +1,20 @@
 use ammonia::Builder;
+use regex::Regex;
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+static PREHEADER_PADDING_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:(?:&nbsp;|\x{00A0})[\x{200B}-\x{200D}\x{FEFF}]*){3,}").unwrap()
+});
+
+static EXCESSIVE_BR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:<br\s*/?>[\s]*){3,}").unwrap());
+
+static EMPTY_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<div>\s*(?:&nbsp;|\x{00A0})?\s*</div>|<p>\s*(?:&nbsp;|\x{00A0})?\s*</p>").unwrap()
+});
+
+static MULTI_NEWLINES_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
 
 pub fn sanitize_html(html: &str) -> String {
     let mut builder = Builder::new();
@@ -47,7 +62,16 @@ pub fn sanitize_html(html: &str) -> String {
         .url_schemes(HashSet::from(["http", "https"]));
 
     let sanitized = builder.clean(html).to_string();
-    remove_tracking_pixels(&sanitized)
+    let cleaned = clean_email_noise(&sanitized);
+    remove_tracking_pixels(&cleaned)
+}
+
+fn clean_email_noise(html: &str) -> String {
+    let result = PREHEADER_PADDING_RE.replace_all(html, " ");
+    let result = EXCESSIVE_BR_RE.replace_all(&result, "<br><br>");
+    let result = EMPTY_BLOCK_RE.replace_all(&result, "");
+    let result = MULTI_NEWLINES_RE.replace_all(&result, "\n\n");
+    result.trim().to_string()
 }
 
 fn remove_tracking_pixels(html: &str) -> String {
@@ -148,5 +172,89 @@ mod tests {
         assert!(result.contains("&amp;"));
         assert!(result.contains("<br>"));
         assert!(result.contains("</p><p>"));
+    }
+
+    #[test]
+    fn strips_preheader_padding() {
+        let padding = "&nbsp;\u{200C}".repeat(50);
+        let html = format!("<div>{padding}</div><p>real content</p>");
+        let result = clean_email_noise(&html);
+        assert!(
+            !result.contains("&nbsp;\u{200C}&nbsp;"),
+            "preheader padding should be stripped"
+        );
+        assert!(result.contains("real content"));
+    }
+
+    #[test]
+    fn preserves_one_or_two_nbsp() {
+        let html = "<p>hello&nbsp;&nbsp;world</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
+    fn collapses_excessive_br() {
+        let html = "<p>one</p><br><br><br><br><br><p>two</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>one</p><br><br><p>two</p>");
+    }
+
+    #[test]
+    fn removes_empty_div_with_nbsp() {
+        let html = "<div>&nbsp;</div><p>content</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn removes_empty_div() {
+        let html = "<div>  </div><p>content</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn removes_empty_p() {
+        let html = "<p></p><p>content</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn preserves_div_with_content() {
+        let html = "<div>hello world</div>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
+    fn collapses_multi_newlines() {
+        let html = "<p>one</p>\n\n\n\n\n<p>two</p>";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>one</p>\n\n<p>two</p>");
+    }
+
+    #[test]
+    fn trims_leading_trailing_whitespace() {
+        let html = "\n\n  <p>content</p>  \n\n";
+        let result = clean_email_noise(html);
+        assert_eq!(result, "<p>content</p>");
+    }
+
+    #[test]
+    fn clean_email_noise_integration() {
+        let padding = "&nbsp;\u{200C}".repeat(100);
+        let html = format!(
+            "\n  <div>{padding}</div>\n<p>real</p><br><br><br><br><div>&nbsp;</div><p></p><p>end</p>\n\n"
+        );
+        let result = clean_email_noise(&html);
+        assert!(!result.contains("&nbsp;\u{200C}&nbsp;"));
+        assert!(result.contains("<p>real</p>"));
+        assert!(result.contains("<p>end</p>"));
+        assert!(!result.contains("<p></p>"));
+        assert!(!result.contains("<div>&nbsp;</div>"));
+        let br_count = result.matches("<br>").count();
+        assert!(br_count <= 2, "expected at most 2 <br>, got {br_count}");
     }
 }

--- a/src/sanitize.rs
+++ b/src/sanitize.rs
@@ -204,6 +204,25 @@ mod tests {
     }
 
     #[test]
+    fn strips_ten_or_more_plain_nbsp() {
+        let nbsp_10 = "&nbsp;".repeat(10);
+        let html = format!("<p>{nbsp_10}text</p>");
+        let result = clean_email_noise(&html);
+        assert!(
+            !result.contains("&nbsp;&nbsp;"),
+            "10+ plain NBSP should be stripped"
+        );
+    }
+
+    #[test]
+    fn preserves_nine_plain_nbsp() {
+        let nbsp_9 = "&nbsp;".repeat(9);
+        let html = format!("<p>{nbsp_9}text</p>");
+        let result = clean_email_noise(&html);
+        assert_eq!(result, html);
+    }
+
+    #[test]
     fn preserves_nbsp_indentation_in_pre() {
         let html = "<pre>&nbsp;&nbsp;&nbsp;indent</pre>";
         let result = clean_email_noise(html);


### PR DESCRIPTION
## Summary
- Add post-ammonia cleanup pass (`clean_email_noise`) that targets common email marketing artifacts
- Strip NBSP padding via two-branch regex:
  - NBSP + zero-width chars (ZWNJ/ZWJ/ZWSP): 3+ repetitions (true preheader padding)
  - Plain NBSP-only runs: 10+ repetitions (excessive spacing noise)
- Collapse excessive `<br>` tags (3+) down to 2
- Remove empty block elements (`<div>&nbsp;</div>`, `<p></p>`, etc.) in a loop until stable, handling nested empties
- Normalize excessive inter-tag newlines and trim leading/trailing whitespace
- Preserves meaningful `&nbsp;` usage (short runs, `<pre>` indentation) and all actual content

## Context
Newsletters (e.g. ActiveCampaign-based) embed preheader padding — hundreds of `&nbsp;‌` repetitions — to control inbox preview text. This is invisible in email clients but produces massive noise in Atom feed XML. These cleanups reduce feed size and improve readability without altering meaningful content.

## Test plan
- [x] 21 unit tests covering each cleanup pattern, edge cases, and integration
- [x] All 80 tests pass (including existing suite)
- [x] Clippy clean