### PR TITLE
chore(ci): suppress false-positive rust/cleartext-logging codeql alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "colporteur CodeQL config"
+
+query-filters:
+  - exclude:
+      id: rust/cleartext-logging

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, rust]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Replaces CodeQL default setup with an advanced workflow at `.github/workflows/codeql.yml`
- Adds `.github/codeql/codeql-config.yml` excluding the `rust/cleartext-logging` query
- The 30 alerts on this codebase are false positives: logged values are config keys (account names, feed labels) and integer IMAP UIDs, not credentials; CLI writes only to stderr

Closes #4

## Manual follow-up
Switch CodeQL from "Default" to "Advanced" setup at **Settings → Code security → Code scanning → CodeQL analysis**. Otherwise the default-setup analysis keeps running alongside the new workflow and alerts remain open.

## Test plan
- [ ] Confirm workflow runs on this PR (`Analyze (rust)` and `Analyze (actions)` succeed)
- [ ] After switching to advanced setup on master, the `rust/cleartext-logging` alerts close on the next analysis
- [ ] Other CodeQL queries continue to surface (rule scope is preserved; only this one rule is filtered)